### PR TITLE
Chore/fix header nav

### DIFF
--- a/frontend/src/components/Bookshelves/Bookshelves.js
+++ b/frontend/src/components/Bookshelves/Bookshelves.js
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Row from 'react-bootstrap/Row';
-import Col from 'react-bootstrap/Col';
 import Container from 'react-bootstrap/Container';
-import { NavLink } from 'react-router-dom';
 import Bookshelf from './Bookshelf';
 import { GetBookshelves } from '../../services/bookshelves'
 
@@ -31,21 +29,11 @@ function Bookshelves() {
 
   return (
     <Container>
-      <Row>
-        <Col><h2>Bookshelves</h2></Col>
-        <Col>
-          <NavLink 
-            className="nav-link" 
-            to="/bookshelves/create/"
-            >
-              Create Bookshelf
-          </NavLink>
-        </Col>
-      </Row>
       <Row className="mt-3 mb-3">
         {bookshelves.map((bookshelf) => (
           <Bookshelf
             bookshelfId={bookshelf.id}
+            preview={true}
           />
         ))}
       </Row>

--- a/frontend/src/components/common/Header.js
+++ b/frontend/src/components/common/Header.js
@@ -1,58 +1,43 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { Container } from 'react-bootstrap'
 import Nav from 'react-bootstrap/Nav';
-import { useLocation, Link, NavLink } from 'react-router-dom';
-import Button from 'react-bootstrap/Button';
-import { Container, Row, Col } from 'react-bootstrap'
+import { Navbar } from 'react-bootstrap';
+import NavDropdown from 'react-bootstrap/NavDropdown';
 
 function Header() {
-  const location = useLocation();
 
   return (    
-    <Container>
-      <Row>
-        <Col>
-          <Link className="navbar-brand" to="/"><h1 class="display-2">Welcome to your Book Case</h1></Link>
-        </Col>
-      </Row>
-      <Row className="align-items-center">
-        <Col>
-          <Nav variant="pills">
-            <Nav.Item>
-              <Nav.Link href="/" active={location.pathname === '/'}>
-                <h1>Bookshelves</h1>
-              </Nav.Link>
-            </Nav.Item>
-            <Nav.Item>
-              <Nav.Link href="/books/" active={location.pathname === '/books/'}>
-                <h1>Books</h1>
-              </Nav.Link>
-            </Nav.Item>
+    <Navbar collapseOnSelect expand="lg" className="bg-body-tertiary">
+      <Container>
+        <Navbar.Brand href="#home">
+          <Link className="navbar-brand" to="/">
+            <h1 class="display-2">Welcome to your Book Case</h1>
+          </Link>
+        </Navbar.Brand>
+        <Navbar.Toggle aria-controls="basic-navbar-nav" />
+        <Navbar.Collapse id="responsive-navbar-nav">
+          <Nav className="me-auto">
+            <NavDropdown title="Bookshelves">
+              <NavDropdown.Item href="/">
+                View
+              </NavDropdown.Item>
+              <NavDropdown.Item href="/bookshelves/create/">
+                Create
+              </NavDropdown.Item>
+            </NavDropdown>
+            <NavDropdown title="Books">
+              <NavDropdown.Item href="/books/">
+                View
+              </NavDropdown.Item>
+              <NavDropdown.Item href="/books/create/">
+                Create
+              </NavDropdown.Item>
+            </NavDropdown>
           </Nav>
-        </Col>
-        <Col style={{
-          textAlign:"right"
-        }}>
-          { location.pathname === '/' && (
-            <NavLink 
-              className="nav-link" 
-              to="/bookshelves/create/"
-              >
-                <Button variant="info">Create Bookshelf</Button>{' '}
-            </NavLink>
-          )}
-
-          { location.pathname === '/books/' && (
-            <NavLink 
-              className="nav-link" 
-              to="/books/create/"
-              >
-                <Button variant="info">Create Book</Button>{' '}
-            </NavLink>
-          )}
-          
-        </Col>
-      </Row>
-    </Container>
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
   );
 }
 

--- a/frontend/src/components/common/Header.js
+++ b/frontend/src/components/common/Header.js
@@ -1,43 +1,58 @@
 import React from 'react';
-import { Link, NavLink } from 'react-router-dom';
+import Nav from 'react-bootstrap/Nav';
+import { useLocation, Link, NavLink } from 'react-router-dom';
+import Button from 'react-bootstrap/Button';
+import { Container, Row, Col } from 'react-bootstrap'
 
 function Header() {
-  return (
-    <nav className="navbar navbar-expand-lg navbar-light bg-light">
-      <div className="container-fluid">
-        <Link className="navbar-brand" to="/"><h1 class="display-2">Welcome to your Book Case</h1></Link>
-        <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-          <span className="navbar-toggler-icon"></span>
-        </button>
-        <div className="collapse navbar-collapse" id="navbarNav">
-          <ul className="navbar-nav">
-            <li className="nav-item">
-              <NavLink 
-                className="nav-link" 
-                to="/"
-                style={({ isActive }) => ({
-                    color: isActive ? '#fff' : '#545e6f',
-                    background: isActive ? '#7600dc' : '#f0f0f0',
-                  })}>
-                    Bookshelves
-              </NavLink>
-            </li>
-            <li className="nav-item">
-              <NavLink 
-                className="nav-link" 
-                to="/bookshelves/create"
-                style={({ isActive }) => ({
-                    color: isActive ? '#fff' : '#545e6f',
-                    background: isActive ? '#7600dc' : '#f0f0f0',
-                  })}>
-                    Create Bookshelf
-              </NavLink>
-              {/* <NavLink className="nav-link" to="/bookshelves/create">Create Bookshelf</NavLink> */}
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
+  const location = useLocation();
+
+  return (    
+    <Container>
+      <Row>
+        <Col>
+          <Link className="navbar-brand" to="/"><h1 class="display-2">Welcome to your Book Case</h1></Link>
+        </Col>
+      </Row>
+      <Row className="align-items-center">
+        <Col>
+          <Nav variant="pills">
+            <Nav.Item>
+              <Nav.Link href="/" active={location.pathname === '/'}>
+                <h1>Bookshelves</h1>
+              </Nav.Link>
+            </Nav.Item>
+            <Nav.Item>
+              <Nav.Link href="/books/" active={location.pathname === '/books/'}>
+                <h1>Books</h1>
+              </Nav.Link>
+            </Nav.Item>
+          </Nav>
+        </Col>
+        <Col style={{
+          textAlign:"right"
+        }}>
+          { location.pathname === '/' && (
+            <NavLink 
+              className="nav-link" 
+              to="/bookshelves/create/"
+              >
+                <Button variant="info">Create Bookshelf</Button>{' '}
+            </NavLink>
+          )}
+
+          { location.pathname === '/books/' && (
+            <NavLink 
+              className="nav-link" 
+              to="/books/create/"
+              >
+                <Button variant="info">Create Book</Button>{' '}
+            </NavLink>
+          )}
+          
+        </Col>
+      </Row>
+    </Container>
   );
 }
 


### PR DESCRIPTION
This PR aims to simply clean up the top nav / common header component. Simpler, smaller links for bookshelves and books, with dropdown for viewing and creation. 

Previously, the large 'Bookshelves' and 'Books' buttons were not ideal because while we had an active state on them if we were on their page, there was no clean/ easy way to add the 'create' feature on top of it, and when the user visited a page that wasn't top level bookshelves or books, neither button was in an active state.