### PR TITLE
Chore/cache open library images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ frontend/.env.production.local
 frontend/npm-debug.log*
 frontend/yarn-debug.log*
 frontend/yarn-error.log*
+
+# static assets
+frontend/public/assets

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -4,6 +4,8 @@ from app.models.book import Book, BookUpdate, Category
 from app.services.openlibrary import OpenLibrary
 from app.db.sqlite import get_db
 import inspect
+import urllib.request
+import os
 
 openlibrary = OpenLibrary()
 
@@ -32,11 +34,24 @@ async def create_book(
     olid = openlibrary.find_olid(olid_response=search_results)
 
     if olid is None:
-        return {"No cover found"}
+        
+        filepath_for_db = '/assets/cover_images/No_Image_Available.jpg'
+
+    else:
     
-    cover_image = "https://covers.openlibrary.org/b/olid/{olid}-M.jpg".format(olid=olid)
-    
-    db.execute(query='INSERT INTO books (title, author, year, category, cover_image) VALUES (?, ?, ?, ?, ?)', values=(book.title, book.author, book.year, book.category, cover_image))
+        cover_image = "https://covers.openlibrary.org/b/olid/{olid}-M.jpg".format(olid=olid)
+
+        # Determine local filename for saving
+        dirname = os.path.dirname(__file__)
+        book_title_as_filename = "".join(c for c in book.title if c.isalpha() or c.isdigit() or c==' ').replace(' ', '_').rstrip()
+        final_filename = os.path.join(dirname, '../../../frontend/public/assets/cover_images/' + book_title_as_filename + '.jpg')
+
+        # Fetch and save file
+        urllib.request.urlretrieve(cover_image, final_filename)
+        
+        filepath_for_db = '/assets/cover_images/' + book_title_as_filename + '.jpg'
+
+    db.execute(query='INSERT INTO books (title, author, year, category, cover_image) VALUES (?, ?, ?, ?, ?)', values=(book.title, book.author, book.year, book.category, filepath_for_db))
     return None
 
 @router.patch("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Here we are simply downloading and storing Open Library images to serve from our app as static files rather than hotlink to their platform.

Open Library docs say: "If you want to display covers on public-facing pages, please use a src URL that points to covers.openlibrary.org.", it is yet to be determined if this will end up as a 'public-facing website'. If it is, I will re-visit how this is handled as I don't want to run afoul of their licenses or rules. 

Similarly, they do say "The cover access by ids other than CoverID and OLID are rate-limited. Currently only 100 requests/IP are allowed for every 5 minutes.". So because we are using OLID images, I believe we shouldn't be rate-limited.

Link to docs:
https://openlibrary.org/dev/docs/api/covers