### PR TITLE
Chore: cleanup cover image database storage

### DIFF
--- a/backend/app/db/adhoc.py
+++ b/backend/app/db/adhoc.py
@@ -1,0 +1,42 @@
+import sqlite3
+
+def rename_cover_image_to_cover_uri_in_books_table():
+    connection = sqlite3.connect('backend/app/bookshelf.db', check_same_thread=False)
+    connection.row_factory = sqlite3.Row
+    cursor = connection.cursor()
+    cursor.execute('ALTER TABLE books RENAME cover_image TO cover_uri;')
+    connection.commit()
+
+def add_cover_olid_to_books_table():
+    connection = sqlite3.connect('backend/app/bookshelf.db', check_same_thread=False)
+    connection.row_factory = sqlite3.Row
+    cursor = connection.cursor()
+    cursor.execute('''
+        ALTER TABLE books
+        ADD COLUMN cover_olid TEXT;
+    ''')
+    connection.commit()
+
+def remove_column_from_table(column: str, table: str):
+    connection = sqlite3.connect('backend/app/bookshelf.db', check_same_thread=False)
+    connection.row_factory = sqlite3.Row
+    cursor = connection.cursor()
+    cursor.execute(f'''
+        ALTER TABLE {table}
+        DROP COLUMN {column};
+    ''')
+    connection.commit()
+
+def show_table_schema(table: str):
+    connection = sqlite3.connect('backend/app/bookshelf.db', check_same_thread=False)
+    cursor = connection.cursor()
+    cursor.execute(f'''
+        PRAGMA table_info({table});  
+    ''')
+    connection.commit()
+    print(cursor.fetchall())
+
+# rename_cover_image_to_cover_uri_in_books_table()
+# add_cover_olid_to_books_table()
+# show_table_schema('books')
+# remove_column_from_table('bookshelf_id', 'books')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,7 +41,8 @@ async def lifespan(app: FastAPI):
             author TEXT, 
             year INTEGER, 
             category TEXT, 
-            cover_image TEXT
+            cover_olid TEXT,
+            cover_uri TEXT
         )
     ''')
     cursor.execute('''

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -45,11 +45,11 @@ async def create_book(
 
         local_file_destination = image.determine_local_file_destination(filename=sanitized_book_title)
 
-        image.download(cover_image=cover_image, local_filename=local_file_destination)
+        await image.download(remote_url=cover_image, local_filename=local_file_destination)
         
         filepath_for_db = image.get_cover_with_path_for_database(filename=sanitized_book_title)
 
-    db.execute(query='INSERT INTO books (title, author, year, category, cover_olid, cover_uri) VALUES (?, ?, ?, ?, ?)', values=(book.title, book.author, book.year, book.category, olid, filepath_for_db))
+    db.execute(query='INSERT INTO books (title, author, year, category, cover_olid, cover_uri) VALUES (?, ?, ?, ?, ?, ?)', values=(book.title, book.author, book.year, book.category, olid, filepath_for_db))
     return None
 
 @router.patch("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/services/openlibrary.py
+++ b/backend/app/services/openlibrary.py
@@ -6,8 +6,12 @@ class OpenLibrary:
 
     def __init__(self):
         self.search_url = "https://openlibrary.org/search.json?title={title}"
+        self.cover_image_url = "https://covers.openlibrary.org/b/olid/{olid}-{size}.jpg"
+        # Options are S, M, L
+        self.cover_image_size = "M"
 
     async def search(self, book: Book) -> Dict[str, Any]:
+
         async with httpx.AsyncClient() as client:
             response = await client.get(self.search_url.format(title=book.title))
             response.raise_for_status()
@@ -25,3 +29,7 @@ class OpenLibrary:
                     break
 
         return olid
+    
+    def build_image_url_from_olid(self, olid: str):
+
+        return self.cover_image_url.format(olid=olid, size=self.cover_image_size)

--- a/backend/app/utils/image.py
+++ b/backend/app/utils/image.py
@@ -1,0 +1,38 @@
+import os
+import urllib
+
+class Image:
+
+    def __init__(self):
+
+        self.local_image_directory = '/assets/cover_images/'
+        self.default_cover_image = 'No_Image_Available.jpg'
+        self.relative_path_to_file = '../../../frontend/public/assets/cover_images/{filename}.jpg'
+
+    def sanitize_book_title_for_filename(self, book_title: str) -> str:
+
+        return "".join(c for c in book_title if c.isalpha() or c.isdigit() or c==' ').replace(' ', '_').rstrip()
+
+    def determine_local_file_destination(self, filename: str) -> str:
+
+        # Determine directory of our file
+        current_directory = os.path.dirname(__file__)
+
+        # Assemble final local file destination
+        return os.path.join(current_directory, self.relative_path_to_file.format(filename=filename))
+        
+    def download(self, remote_url: str, local_filename: str) -> None:
+
+        return urllib.request.urlretrieve(remote_url, local_filename)
+    
+    def get_local_image_directory(self) -> str:
+
+        return self.local_image_directory
+    
+    def get_default_cover_with_path_for_database(self) -> str:
+
+        return self.local_image_directory + self.default_cover_image
+    
+    def get_cover_with_path_for_database(self, filename: str) -> str:
+
+        return self.local_image_directory + filename

--- a/backend/app/utils/image.py
+++ b/backend/app/utils/image.py
@@ -7,7 +7,8 @@ class Image:
 
         self.local_image_directory = '/assets/cover_images/'
         self.default_cover_image = 'No_Image_Available.jpg'
-        self.relative_path_to_file = '../../../frontend/public/assets/cover_images/{filename}.jpg'
+        self.relative_path_to_file = '../../../frontend/public/assets/cover_images/{filename}{extension}'
+        self.image_file_extension = '.jpg'
 
     def sanitize_book_title_for_filename(self, book_title: str) -> str:
 
@@ -19,9 +20,9 @@ class Image:
         current_directory = os.path.dirname(__file__)
 
         # Assemble final local file destination
-        return os.path.join(current_directory, self.relative_path_to_file.format(filename=filename))
+        return os.path.join(current_directory, self.relative_path_to_file.format(filename=filename, extension=self.image_file_extension))
         
-    def download(self, remote_url: str, local_filename: str) -> None:
+    async def download(self, remote_url: str, local_filename: str) -> None:
 
         return urllib.request.urlretrieve(remote_url, local_filename)
     
@@ -35,4 +36,4 @@ class Image:
     
     def get_cover_with_path_for_database(self, filename: str) -> str:
 
-        return self.local_image_directory + filename
+        return self.local_image_directory + filename + self.image_file_extension

--- a/frontend/src/components/Bookshelves/Bookshelf.js
+++ b/frontend/src/components/Bookshelves/Bookshelf.js
@@ -167,13 +167,13 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
         {books.map((book) => (
             <Col md="auto" className="mt-3">
               <div class="bookshelf-book-image-wrapper">
-                <img height="150px" src={book.cover_image} alt="Book Cover" /> 
+                <img height="150px" src={book.cover_uri} alt="Book Cover" /> 
                 { ! preview && (
                   <div class="remove-book-from-bookshelf-button">
                     <button class="btn btn-close" onClick={(event) => {handleDeleteBookFromBookshelf(event, book.id)}}></button>
                   </div>
                 )}
-              </div>
+              </div>  
             </Col>
           ))}
       </Row>
@@ -186,7 +186,7 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
             <Row>
               {booksThatCanBeAdded.map((book) => (
                 <Col>
-                  <img src={book.cover_image} onClick={(event) => toggleBookSelection(event, book.id)} alt="Book Cover" class="border border-2 border-light" style={{'boxSizing': 'border-box', 'height': '175px', 'padding': '2px'}} /> 
+                  <img src={book.cover_uri} onClick={(event) => toggleBookSelection(event, book.id)} alt="Book Cover" class="border border-2 border-light" style={{'boxSizing': 'border-box', 'height': '175px', 'padding': '2px'}} /> 
                 </Col>
               ))}
             </Row>

--- a/frontend/src/components/books/Book.js
+++ b/frontend/src/components/books/Book.js
@@ -25,7 +25,7 @@ function Book({ bookId = null, preview = false }) {
       setAuthor(data.author);
       setYear(data.year);
       setCategory(data.category);
-      setCover(data.cover_image);
+      setCover(data.cover_uri);
     } catch (error) {
       console.error('Error fetching book:', error);
     } finally {


### PR DESCRIPTION
This PR aims to clean up how we handle downloading and referencing Open Library images.

Firstly, we move some of this functionality into its own utility class to stop polluting the router business logic.

Secondly, we store the OLID for future reference, alongside a single local file path where we actually have the image stored.

The OLID would allow us to go back and fetch the image, or additional metadata in the future.