### PR TITLE
Lazy Loading Images

### DIFF
--- a/frontend/src/components/Bookshelves/Bookshelf.js
+++ b/frontend/src/components/Bookshelves/Bookshelf.js
@@ -7,6 +7,7 @@ import Modal from 'react-bootstrap/Modal';
 import { NavLink, useParams, useNavigate } from 'react-router-dom';
 import { GetBookshelfBooks, GetBookshelf, DeleteBookshelf, GetBooksNotOnBookshelf, AddBooksToBookshelf, DeleteBookFromBookshelf } from '../../services/bookshelves'
 import {confirm} from 'react-bootstrap-confirmation';
+import LazyImage from '../common/LazyLoadImage';
 
 function Bookshelf({ bookshelfId = null, preview = false }) {
 
@@ -126,27 +127,27 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
   return (
     <Container>
       <Row className="mt-4 align-items-center" style={{ 'borderBottom': '3px solid black'}}>
-          <Col xs={9}>
-          { preview && (
-            <NavLink 
-              className="nav-link" 
-              to={"/bookshelves/" + id}
-              >
-                <h1 className="display-6 pull-left">{data.title}</h1>
-            </NavLink>
-          )}
-          { ! preview && (
-            <h1 className="display-5 pull-left">{data.title}</h1>
-          )}
+        <Col xs={9}>
+        { preview && (
+          <NavLink 
+            className="nav-link" 
+            to={"/bookshelves/" + id}
+            >
+              <h1 className="display-6 pull-left">{data.title}</h1>
+          </NavLink>
+        )}
+        { ! preview && (
+          <h1 className="display-5 pull-left">{data.title}</h1>
+        )}
+        </Col>
+        { ! preview && (
+          <Col xs={3} style={{
+            textAlign:"right"
+          }}>
+            <button type="button" className="btn btn-primary" onClick={handleUpdate}>Update</button>
+            <button type="button" className="btn btn-danger ms-1" onClick={handleDelete}>Delete</button>
           </Col>
-          { ! preview && (
-            <Col xs={3} style={{
-              textAlign:"right"
-            }}>
-              <button type="button" className="btn btn-primary" onClick={handleUpdate}>Update</button>
-              <button type="button" className="btn btn-danger ms-1" onClick={handleDelete}>Delete</button>
-            </Col>
-          )}
+        )}
       </Row>
       <Row className="mt-2 align-items-center">
         <Col md="auto">
@@ -158,24 +159,30 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
           )}
         </Col>
       </Row>
-      <Row className="mt-2">
+      <Row className="mt-2" style={{ 'min-height': '150px' }}>
         { ! preview && (
           <Col md="auto" className="mt-3">
             <button type="button" className="btn btn-outline-primary" style={{ 'width': '90px', 'height': '150px' }} onClick={handleShowModal}>+</button>
           </Col>
         )}
         {books.map((book) => (
-            <Col md="auto" className="mt-3">
-              <div class="bookshelf-book-image-wrapper">
-                <img height="150px" src={book.cover_uri} alt="Book Cover" /> 
-                { ! preview && (
-                  <div class="remove-book-from-bookshelf-button">
-                    <button class="btn btn-close" onClick={(event) => {handleDeleteBookFromBookshelf(event, book.id)}}></button>
-                  </div>
-                )}
-              </div>  
-            </Col>
-          ))}
+          <Col md="auto" className="mt-3" style={{ 'min-height': '150px', 'min-width': '80px' }}>
+            <div class="bookshelf-book-image-wrapper" style={{ 'min-height': '150px', 'min-width': '80px' }}>
+              <img 
+                height="150px" 
+                src={book.cover_uri} 
+                alt="Book Cover" 
+                loading="lazy" 
+                style={{ 'height': '150px', 'min-height': '150px', 'min-width': '80px' }}
+              />
+              { ! preview && (
+                <div class="remove-book-from-bookshelf-button">
+                  <button class="btn btn-close" onClick={(event) => {handleDeleteBookFromBookshelf(event, book.id)}}></button>
+                </div>
+              )}
+            </div>  
+          </Col>
+        ))}
       </Row>
       <Modal size="lg" contentClassName="add-books-to-bookshelf-modal" show={showModal} onShow={fetchBooksThatCanBeAdded} onHide={handleCloseModal} onExit={handleResetBooksToAdd} centered>
         <Modal.Header closeButton>
@@ -185,8 +192,18 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
           <Container>
             <Row>
               {booksThatCanBeAdded.map((book) => (
-                <Col>
-                  <img src={book.cover_uri} onClick={(event) => toggleBookSelection(event, book.id)} alt="Book Cover" class="border border-2 border-light" style={{'boxSizing': 'border-box', 'height': '175px', 'padding': '2px'}} /> 
+                <Col 
+                  className='m-3'
+                  onClick={(event) => toggleBookSelection(event, book.id)}
+                  style={{'height': '175px', 'min-height': '175px', 'min-width': '100px', 'padding': '2px'}}
+                >
+                  <LazyImage 
+                    src={book.cover_uri} 
+                    alt="Book Cover" 
+                    class="border border-2 border-light" 
+                    style={{'boxSizing': 'border-box', 'height': '175px', 'min-height': '175px', 'min-width': '100px', 'padding': '2px'}}
+                    rootElement={document.querySelector('.modal-content')}
+                  ></LazyImage>
                 </Col>
               ))}
             </Row>

--- a/frontend/src/components/Bookshelves/Bookshelves.js
+++ b/frontend/src/components/Bookshelves/Bookshelves.js
@@ -29,14 +29,14 @@ function Bookshelves() {
 
   return (
     <Container>
-      <Row className="mt-3 mb-3">
-        {bookshelves.map((bookshelf) => (
+      {bookshelves.map((bookshelf) => (
+        <Row className="mt-3 mb-3" style={{ 'min-height': '250px' }} key={bookshelf.id}>
           <Bookshelf
             bookshelfId={bookshelf.id}
             preview={true}
           />
-        ))}
-      </Row>
+        </Row>
+      ))}
     </Container>
   );
 }

--- a/frontend/src/components/books/Book.js
+++ b/frontend/src/components/books/Book.js
@@ -136,7 +136,7 @@ function Book({ bookId = null, preview = false }) {
                 className="nav-link" 
                 to={"/books/" + id}
               >
-                <img src={coverUri} className="img-fluid" alt="Book Cover" />
+                <img src={coverUri} className="img-fluid" alt="Book Cover" loading="lazy" />
               </NavLink>
             </Col>
             <Col className={ ! preview ? 'col-auto' : '' } xs={ preview ? 9 : null }>
@@ -202,6 +202,7 @@ function Book({ bookId = null, preview = false }) {
                     onClick={(event) => toggleBookCoverSelection(event, map_olid)} 
                     className={`border border-2 ${olid === map_olid ? 'border-primary' : 'border-light' }`}
                     alt='Book Cover'
+                    loading='lazy'
                   />
                 </Col>
               ))}

--- a/frontend/src/components/books/CreateBook.js
+++ b/frontend/src/components/books/CreateBook.js
@@ -194,6 +194,7 @@ function CreateBook() {
                         onClick={(event) => toggleBookCoverSelection(event, map_olid)} 
                         className={`border border-2 ${olid === map_olid ? 'border-primary' : 'border-light' }`}
                         alt='Book Cover'
+                        loading='lazy'
                       />
                     </Col>
                   ))}

--- a/frontend/src/components/common/LazyLoadImage.js
+++ b/frontend/src/components/common/LazyLoadImage.js
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react';
+
+const LazyImage = ({ src, alt, element_class, style, rootElement }) => {
+  const imgRef = useRef();
+
+  console.log('root element', rootElement);
+
+  useEffect(() => {
+
+    if (!rootElement) return;
+    
+    const currentImgRef = imgRef.current;
+
+    const observer = new IntersectionObserver(
+        (entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    imgRef.current.src = src;
+                    observer.unobserve(entry.target);
+                }
+            });
+        },
+        {
+            root: rootElement || null,
+            threshold: 0.1,
+            rootMargin: '0px 0px 50px 0px',
+        }
+    );
+    
+    if (currentImgRef) {
+        observer.observe(currentImgRef);
+    }
+    
+  }, [src, rootElement]);
+
+  return <img ref={imgRef} data-src={src} alt={alt} loading="lazy" class={element_class} style={style}/>;
+};
+
+export default LazyImage;


### PR DESCRIPTION
Now that I'm starting to add a fair amount of books and book covers to the app, we want to lazy load the images so we aren't bogging down the UX with loading hundreds of images off screen.

A combination of basic 'loading: lazy' property for images, and a bit of custom config for the <Modal> seem to get the job done for now.

May need to keep investigating with additional views, or as certain views grow larger.

Closes #13 