### PR TITLE
Removing Category

### DIFF
--- a/backend/app/db/adhoc.py
+++ b/backend/app/db/adhoc.py
@@ -57,9 +57,20 @@ def add_rating_and_review_to_books_table():
     ''')
     connection.commit()
 
+def remove_category_column_from_book_table():
+    connection = sqlite3.connect('backend/app/bookshelf.db', check_same_thread=False)
+    connection.row_factory = sqlite3.Row
+    cursor = connection.cursor()
+    cursor.execute('''
+        ALTER TABLE books
+        DROP COLUMN category;
+    ''')
+    connection.commit()
+
 # rename_cover_image_to_cover_uri_in_books_table()
 # add_cover_olid_to_books_table()
 # show_table_schema('books')
 # remove_column_from_table('bookshelf_id', 'books')
 # rename_cover_olid_to_olid_in_books_table()
-add_rating_and_review_to_books_table()
+# add_rating_and_review_to_books_table()
+remove_category_column_from_book_table()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,7 +40,6 @@ async def lifespan(app: FastAPI):
             title TEXT, 
             author TEXT, 
             year INTEGER, 
-            category TEXT, 
             olid TEXT,
             cover_uri TEXT,
             rating INTEGER

--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -1,48 +1,10 @@
 from pydantic import BaseModel, create_model
 from typing import Optional
-from enum import StrEnum
-
-class Category(StrEnum):
-    action_adventure = "Action & Adventure"
-    art_photography = "Art & Photography"
-    biography = "Biography"
-    children_s = "Children's"
-    contemporary_fiction = "Contemporary Fiction"
-    dystopian = "Dystopian"
-    essays = "Essays"
-    fantasy = "Fantasy"
-    food_drink = "Food & Drink"
-    graphic_novel = "Graphic Novel"
-    guide_how_to = "Guide/How-to"
-    historical_fiction = "Historical Fiction"
-    history = "History"
-    horror = "Horror"
-    humanities_social_sciences = "Humanities & Social Sciences"
-    humor = "Humor"
-    lgbtq = "LGBTQ+"
-    literary_fiction = "Literary Fiction"
-    magical_realism = "Magical Realism"
-    memoir_autobiography = "Memoir & Autobiography"
-    mystery = "Mystery"
-    new_adult = "New Adult"
-    parenting_families = "Parenting & Families"
-    religion_spirituality = "Religion & Spirituality"
-    romance = "Romance"
-    science_technology = "Science & Technology"
-    science_fiction = "Science Fiction"
-    self_help = "Self-help"
-    short_story = "Short Story"
-    thriller_suspense = "Thriller & Suspense"
-    travel = "Travel"
-    true_crime = "True Crime"
-    women_s_fiction = "Women's Fiction"
-    young_adult = "Young Adult"
 
 class Book(BaseModel):
     title: str
     author: str
     year: int
-    category: Category
     olid: Optional[str] = None
     rating: Optional[int] = None
     review: Optional[str] = None

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Path, status
 from typing import Annotated
-from app.models.book import Book, BookUpdate, Category
+from app.models.book import Book, BookUpdate
 from app.models.openlibrary import Work
 from app.services.openlibrary import OpenLibrary
 from app.db.sqlite import get_db
@@ -46,7 +46,7 @@ async def create_book(
         
         filepath_for_db = image.get_cover_with_path_for_database(filename=book.olid)
 
-    db.execute(query='INSERT INTO books (title, author, year, category, olid, cover_uri) VALUES (?, ?, ?, ?, ?, ?)', values=(book.title, book.author, book.year, book.category, book.olid, filepath_for_db))
+    db.execute(query='INSERT INTO books (title, author, year, olid, cover_uri) VALUES (?, ?, ?, ?, ?)', values=(book.title, book.author, book.year, book.olid, filepath_for_db))
     return None
 
 @router.patch("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -91,11 +91,6 @@ def delete_bookshelf(
 ):
     db.execute(query='DELETE FROM books WHERE id = ?', values=(book_id,))
     return None
-
-@router.get("/categories/", status_code=status.HTTP_200_OK)
-def get_book_categories():
-    attributes = inspect.getmembers(Category, lambda a:not(inspect.isroutine(a)))
-    return [a[1] for a in attributes if not(a[0].startswith('__') and a[0].endswith('__'))]
 
 @router.get("/search/{title}", status_code=status.HTTP_200_OK)
 async def search_by_title(

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -21,7 +21,6 @@ class DB:
                 title TEXT, 
                 author TEXT, 
                 year INTEGER, 
-                category TEXT, 
                 cover_image TEXT
             )
         ''')

--- a/backend/app/tests/integration/test_routes.py
+++ b/backend/app/tests/integration/test_routes.py
@@ -47,34 +47,34 @@ def test_get_books():
     assert response.json() == []
 
 def test_create_book():
-    body = {'title': 'Book Title', 'author': 'Book Author', 'year': 2000, 'category': 'Biography'}
+    body = {'title': 'Book Title', 'author': 'Book Author', 'year': 2000}
     response = client.post("/books", json=body)
     assert response.status_code == 201
     assert response.json() == None
 
 def test_get_books_after_create():
     book_id = 1
-    result = [{'id': book_id, 'title': 'Book Title', 'author': 'Book Author', 'year': 2000, 'category': 'Biography', 'cover_image': 'https://covers.openlibrary.org/b/olid/12345-M.jpg'}]
+    result = [{'id': book_id, 'title': 'Book Title', 'author': 'Book Author', 'year': 2000, 'cover_image': 'https://covers.openlibrary.org/b/olid/12345-M.jpg'}]
     response = client.get("/books")
     assert response.status_code == 200
     assert response.json() == result
 
 def test_get_book():
     book_id = 1
-    result = {'id': book_id, 'title': 'Book Title', 'author': 'Book Author', 'year': 2000, 'category': 'Biography', 'cover_image': 'https://covers.openlibrary.org/b/olid/12345-M.jpg'}
+    result = {'id': book_id, 'title': 'Book Title', 'author': 'Book Author', 'year': 2000, 'cover_image': 'https://covers.openlibrary.org/b/olid/12345-M.jpg'}
     response = client.get(f"/books/{book_id}")
     assert response.status_code == 200
     assert response.json() == result
 
 def test_patch_book():
-    body = {'title': 'New Book Title', 'author': 'New Book Author', 'year': 1999, 'category': 'Science Fiction', 'cover_image': 'https://covers.openlibrary.org/b/olid/12345-M.jpg'}
+    body = {'title': 'New Book Title', 'author': 'New Book Author', 'year': 1999, 'cover_image': 'https://covers.openlibrary.org/b/olid/12345-M.jpg'}
     book_id = 1
     response = client.patch(f"/books/{book_id}", json=body)
     assert response.status_code == 204
 
 def test_get_book_after_patch():
     book_id = 1
-    result = {'id': book_id, 'title': 'New Book Title', 'author': 'New Book Author', 'year': 1999, 'category': 'Science Fiction', 'cover_image': 'https://covers.openlibrary.org/b/olid/12345-M.jpg'}
+    result = {'id': book_id, 'title': 'New Book Title', 'author': 'New Book Author', 'year': 1999, 'cover_image': 'https://covers.openlibrary.org/b/olid/12345-M.jpg'}
     response = client.get(f"/books/{book_id}")
     assert response.status_code == 200
     assert response.json() == result
@@ -96,7 +96,7 @@ def test_add_book_to_bookshelf():
 def test_get_bookshelf_books_after_add():
     bookshelf_id = 1
     book_id = 1
-    result = [{'id': book_id, 'title': 'New Book Title', 'author': 'New Book Author', 'year': 1999, 'category': 'Science Fiction', 'cover_image': 'https://covers.openlibrary.org/b/olid/12345-M.jpg'}]
+    result = [{'id': book_id, 'title': 'New Book Title', 'author': 'New Book Author', 'year': 1999, 'cover_image': 'https://covers.openlibrary.org/b/olid/12345-M.jpg'}]
     response = client.get(f"/bookshelves/{bookshelf_id}/books")
     assert response.status_code == 200
     assert response.json() == result

--- a/frontend/src/components/books/Book.js
+++ b/frontend/src/components/books/Book.js
@@ -17,7 +17,6 @@ function Book({ bookId = null, preview = false }) {
   const [title, setTitle] = useState('');
   const [author, setAuthor] = useState('');
   const [year, setYear] = useState('');
-  const [category, setCategory] = useState('');
   const [rating, setRating] = useState('');
   const [review, setReview] = useState('');
   const [savedReview, setSavedReview] = useState('');
@@ -37,7 +36,6 @@ function Book({ bookId = null, preview = false }) {
       setTitle(data.title);
       setAuthor(data.author);
       setYear(data.year);
-      setCategory(data.category);
       setOlid(data.olid);
       setSavedOlid(data.olid);
       setCoverUri(data.cover_uri);
@@ -221,18 +219,6 @@ function Book({ bookId = null, preview = false }) {
               <h5>
                 {year}
               </h5>
-            )}
-          </Row>
-          <Row>
-            { preview && (
-              <span>
-                <small>{category}</small>
-              </span>
-            )}
-            { ! preview && (
-              <h6>
-                {category}
-              </h6>
             )}
           </Row>
           <Row className='ms-auto'>

--- a/frontend/src/components/books/CreateBook.js
+++ b/frontend/src/components/books/CreateBook.js
@@ -10,7 +10,6 @@ function CreateBook() {
   const [title, setTitle] = useState('');
   const [author, setAuthor] = useState('');
   const [year, setYear] = useState('');
-  const [category, setCategory] = useState('Literary Fiction');
   const [olid, setOlid] = useState('');
   const [availableCategories, setAvailableCategories] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -52,12 +51,11 @@ function CreateBook() {
 
   const handleCreate = async (e) => {
     e.preventDefault();
-    await CreateBookService({ title, author, year, olid, category });
+    await CreateBookService({ title, author, year, olid });
     setTitle('');
     setSearchTitle('');
     setAuthor('');
     setYear('');
-    setCategory('');
     setOlid('');
     setOlids([]);
     navigate(`/books/`);
@@ -69,7 +67,6 @@ function CreateBook() {
     setSearchTitle('');
     setAuthor('');
     setYear('');
-    setCategory('');
     setOlid('');
     setOlids([]);
     navigate(`/books/`);


### PR DESCRIPTION
Category was originally given by the user, but from a curated hard-coded list fetched from somewhere.

However, in reality, if we are using Open Library, we may want to use genres provided by them. But also, if we did, that is a bit of a minefield in reality, with many genres and subgenres, and a single edition/work having potentially dozens of them assigned.

For now we will remove this entity altogether. Can re-address in the future if it's useful.

It may ultimately be best to allow the user to create their own genres or categories.

Closes #24 