### PR TITLE
Swapping raw SQL, pydantic for SQL Model ORM

### DIFF
--- a/backend/app/db/adhoc.py
+++ b/backend/app/db/adhoc.py
@@ -67,10 +67,23 @@ def remove_category_column_from_book_table():
     ''')
     connection.commit()
 
+def drop_tables_book_and_bookshelf():
+    connection = sqlite3.connect('backend/app/bookshelf.db', check_same_thread=False)
+    connection.row_factory = sqlite3.Row
+    cursor = connection.cursor()
+    cursor.execute('''
+        DROP TABLE book;
+    ''')
+    cursor.execute('''
+        DROP TABLE bookshelf;
+    ''')
+    connection.commit()
+
 # rename_cover_image_to_cover_uri_in_books_table()
 # add_cover_olid_to_books_table()
 # show_table_schema('books')
 # remove_column_from_table('bookshelf_id', 'books')
 # rename_cover_olid_to_olid_in_books_table()
 # add_rating_and_review_to_books_table()
-remove_category_column_from_book_table()
+# remove_category_column_from_book_table()
+# drop_tables_book_and_bookshelf()

--- a/backend/app/db/sqlite.py
+++ b/backend/app/db/sqlite.py
@@ -1,22 +1,21 @@
-import sqlite3
+from sqlmodel import create_engine
 
 class DB:
 
     def __init__(self):
-        self.connection = sqlite3.connect('bookshelf.db', check_same_thread=False)
-        self.connection.row_factory = sqlite3.Row
-        self.cursor = self.connection.cursor()
-        self.cursor.execute("PRAGMA foreign_keys = ON")
-        self.connection.commit()
+        self.sqlite_file_name = "bookshelf.db"
+        self.sqlite_url = f"sqlite:///{self.sqlite_file_name}"
+        self.connect_args = {"check_same_thread": False}
+        self.engine = create_engine(self.sqlite_url, echo=True, connect_args=self.connect_args)
+
+    def get_engine(self):
+        return self.engine
     
-    def execute(self, query: str, values: tuple = ()):
-        self.cursor.execute(query, values)
-        self.connection.commit()
-        return self.cursor
-        
+    def execute(self):
+        pass
+
     def close(self):
-        self.connection.close()
-    
+        pass
 
 def get_db():
     db = DB()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,9 +2,23 @@ from fastapi import FastAPI, Path
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 from app.routers import books, bookshelves
-import sqlite3
+from sqlmodel import SQLModel, text
+from app.models.book import Book # imported for create_all call
+from app.models.bookshelf import Bookshelf # imported for create_all call
+from app.db.sqlite import DB
 
-app = FastAPI()
+db = DB()
+engine = db.get_engine()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    SQLModel.metadata.create_all(engine)
+    with engine.connect() as connection:
+        connection.execute(text("PRAGMA foreign_keys=ON"))  # for SQLite only
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 origins = ["*"]
 
@@ -18,41 +32,3 @@ app.add_middleware(
 
 app.include_router(books.router, prefix="/books", tags=["books"])
 app.include_router(bookshelves.router, prefix="/bookshelves", tags=["bookshelves"])
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    connection = sqlite3.connect('bookshelf.db', check_same_thread=False)
-    cursor = connection.cursor()
-    # self.cursor.execute('''DROP TABLE IF EXISTS bookshelves''')
-    # self.cursor.execute('''DROP TABLE IF EXISTS books''')
-    # self.cursor.execute('''DROP TABLE IF EXISTS bookshelves_books''')
-    cursor.execute("PRAGMA foreign_keys = ON")
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS bookshelves (
-            id INTEGER PRIMARY KEY, 
-            title TEXT, 
-            description TEXT
-        )
-    ''')
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS books (
-            id INTEGER PRIMARY KEY, 
-            title TEXT, 
-            author TEXT, 
-            year INTEGER, 
-            olid TEXT,
-            cover_uri TEXT,
-            rating INTEGER
-            review TEXT
-        )
-    ''')
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS bookshelves_books (
-            bookshelf_id INTEGER,
-            book_id INTEGER,
-            PRIMARY KEY (bookshelf_id, book_id),
-            FOREIGN KEY (bookshelf_id) REFERENCES bookshelves (id) ON DELETE CASCADE,
-            FOREIGN KEY (book_id) REFERENCES books (id) ON DELETE CASCADE
-        )
-    ''')
-    connection.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Path
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 from app.routers import books, bookshelves

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,9 +3,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 from app.routers import books, bookshelves
 from sqlmodel import SQLModel, text
-from app.models.book import Book # imported for create_all call
-from app.models.bookshelf import Bookshelf # imported for create_all call
 from app.db.sqlite import DB
+
+ # These are only imported for the create_all call
+from app.models.book import Book
+from app.models.bookshelf import Bookshelf
+from app.models.book_bookshelf import BookBookshelfLink
 
 db = DB()
 engine = db.get_engine()

--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -1,18 +1,42 @@
-from pydantic import BaseModel, create_model
-from typing import Optional
+from sqlmodel import SQLModel, Field, Relationship
+from pydantic import create_model
+from typing import Optional, TYPE_CHECKING, List
+from app.models.book_bookshelf import BookBookshelfLink
 
-class Book(BaseModel):
+if TYPE_CHECKING:
+    from app.models.bookshelf import Bookshelf  # Only imported when type checking
+
+class BookBase(SQLModel):
     title: str
     author: str
     year: int
     olid: Optional[str] = None
     rating: Optional[int] = None
-    review: Optional[str] = None
+    review: Optional[str] = None  
 
-class BookIds(BaseModel):
-    book_ids: list[int]
+class Book(BookBase, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    cover_uri: str
+    bookshelves: List["Bookshelf"] = Relationship(back_populates="books", link_model=BookBookshelfLink, sa_relationship_kwargs=dict(lazy="selectin"))
+  
+class BookCreate(BookBase):
+    pass
+
+class BookPublic(BookBase):
+    id: int
+    cover_uri: str
 
 BookUpdate = create_model(
     'BookUpdate',
-    **{field: (Optional[type_hint], None) for field, type_hint in Book.__annotations__.items()}
+    **{field: (Optional[type_hint], None) for field, type_hint in BookBase.__annotations__.items()}
 )
+
+class BookPublicWithBookshelves(BookPublic):
+    bookshelves: List["BookshelfPublic"] = []
+
+from app.models.bookshelf import BookshelfPublic
+BookPublicWithBookshelves.model_rebuild()
+
+class BookIds(SQLModel):
+    book_ids: List[int]
+

--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -1,5 +1,4 @@
 from sqlmodel import SQLModel, Field, Relationship
-from pydantic import create_model
 from typing import Optional, TYPE_CHECKING, List
 from app.models.book_bookshelf import BookBookshelfLink
 

--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -26,10 +26,13 @@ class BookPublic(BookBase):
     id: int
     cover_uri: str
 
-BookUpdate = create_model(
-    'BookUpdate',
-    **{field: (Optional[type_hint], None) for field, type_hint in BookBase.__annotations__.items()}
-)
+class BookUpdate(SQLModel):
+    title: Optional[str] = None
+    author: Optional[str] = None
+    year: Optional[int] = None
+    olid: Optional[str] = None
+    rating: Optional[int] = None
+    review: Optional[str] = None
 
 class BookPublicWithBookshelves(BookPublic):
     bookshelves: List["BookshelfPublic"] = []

--- a/backend/app/models/book_bookshelf.py
+++ b/backend/app/models/book_bookshelf.py
@@ -1,0 +1,5 @@
+from sqlmodel import Field, SQLModel
+
+class BookBookshelfLink(SQLModel, table=True):
+    book_id: int | None = Field(default=None, foreign_key="book.id", primary_key=True)
+    bookshelf_id: int | None = Field(default=None, foreign_key="bookshelf.id", primary_key=True)

--- a/backend/app/models/bookshelf.py
+++ b/backend/app/models/bookshelf.py
@@ -1,11 +1,32 @@
-from pydantic import BaseModel, create_model
-from typing import Optional
+from sqlmodel import SQLModel, Field, Relationship
+from pydantic import create_model
+from typing import Optional, TYPE_CHECKING, List
+from app.models.book_bookshelf import BookBookshelfLink
 
-class Bookshelf(BaseModel):
+if TYPE_CHECKING:
+    from app.models.book import Book, BookPublic  # Only imported when type checking
+
+class BookshelfBase(SQLModel):
     title: str
     description: str
 
+class Bookshelf(BookshelfBase, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    books: List["Book"] = Relationship(back_populates="bookshelves", link_model=BookBookshelfLink, sa_relationship_kwargs=dict(lazy="selectin"))
+
+class BookshelfCreate(BookshelfBase):
+    pass
+
+class BookshelfPublic(BookshelfBase):
+    id: int
+
 BookshelfUpdate = create_model(
     'BookshelfUpdate',
-    **{field: (Optional[type_hint], None) for field, type_hint in Bookshelf.__annotations__.items()}
+    **{field: (Optional[type_hint], None) for field, type_hint in BookshelfBase.__annotations__.items()}
 )
+
+class BookshelfPublicWithBooks(BookshelfPublic):
+    books: list["BookPublic"] = []
+
+from app.models.book import BookPublic
+BookshelfPublicWithBooks.model_rebuild()

--- a/backend/app/models/bookshelf.py
+++ b/backend/app/models/bookshelf.py
@@ -1,5 +1,4 @@
 from sqlmodel import SQLModel, Field, Relationship
-from pydantic import create_model
 from typing import Optional, TYPE_CHECKING, List
 from app.models.book_bookshelf import BookBookshelfLink
 

--- a/backend/app/models/bookshelf.py
+++ b/backend/app/models/bookshelf.py
@@ -20,10 +20,9 @@ class BookshelfCreate(BookshelfBase):
 class BookshelfPublic(BookshelfBase):
     id: int
 
-BookshelfUpdate = create_model(
-    'BookshelfUpdate',
-    **{field: (Optional[type_hint], None) for field, type_hint in BookshelfBase.__annotations__.items()}
-)
+class BookshelfUpdate(SQLModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
 
 class BookshelfPublicWithBooks(BookshelfPublic):
     books: list["BookPublic"] = []

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -40,7 +40,7 @@ async def create_book(
     cover_uri = openlibrary.get_cover_uri()
 
     with Session(db.get_engine()) as session:
-        db_book = Book.model_validate(book_create, update={"cover_uri": cover_uri})
+        db_book = book_create.model_validate(book_create, update={"cover_uri": cover_uri})
         session.add(db_book)
         session.commit()
 
@@ -57,12 +57,13 @@ async def update_bookshelf(
         if not db_book:
             raise HTTPException(status_code=404, detail="Book not found")
         
+        book_data = book_update.model_dump(exclude_unset=True)
+
         if book_update.olid:
             await openlibrary.fetch_image_from_olid(book_update.olid)
             cover_uri = openlibrary.get_cover_uri()
-            db_book = Book.model_validate(book_data, update={"cover_uri": cover_uri})
+            book_data.update({"cover_uri": cover_uri})
 
-        book_data = book_update.model_dump(exclude_unset=True)
         db_book.sqlmodel_update(book_data)
         session.add(db_book)
         session.commit()

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -40,7 +40,7 @@ async def create_book(
     cover_uri = openlibrary.get_cover_uri()
 
     with Session(db.get_engine()) as session:
-        db_book = book_create.model_validate(book_create, update={"cover_uri": cover_uri})
+        db_book = Book.model_validate(book_create, update={"cover_uri": cover_uri})
         session.add(db_book)
         session.commit()
 

--- a/backend/app/routers/bookshelves.py
+++ b/backend/app/routers/bookshelves.py
@@ -1,31 +1,43 @@
 from fastapi import APIRouter, Depends, Path, status, HTTPException
 from typing import Annotated, List
-from app.models.bookshelf import Bookshelf, BookshelfUpdate
-from app.models.book import BookIds
+from app.models.bookshelf import Bookshelf, BookshelfCreate, BookshelfUpdate, BookshelfPublic, BookshelfPublicWithBooks
+from app.models.book import BookIds, Book
+from app.models.book_bookshelf import BookBookshelfLink
 from app.db.sqlite import get_db
+from sqlmodel import Session, select
 
 router = APIRouter()
 
-@router.get("/", status_code=status.HTTP_200_OK)
+@router.get("/", status_code=status.HTTP_200_OK, response_model=list[BookshelfPublic])
 def get_bookshelves(
     db = Depends(get_db)
 ):
-    return db.execute(query='SELECT * FROM bookshelves').fetchall()
-
-@router.post("/", status_code=status.HTTP_201_CREATED)
-def create_bookshelf(
-    bookshelf: Bookshelf,
-    db = Depends(get_db)
-):
-    db.execute(query='INSERT INTO bookshelves (title, description) VALUES (?, ?)', values=(bookshelf.title, bookshelf.description))
-    return None
-
-@router.get("/{bookshelf_id}", status_code=status.HTTP_200_OK)
+    with Session(db.get_engine()) as session:
+        bookshelves = session.exec(select(Bookshelf)).all()
+        return bookshelves
+    
+@router.get("/{bookshelf_id}", status_code=status.HTTP_200_OK, response_model=BookshelfPublicWithBooks)
 def get_bookshelf(
     bookshelf_id: Annotated[int, Path(title="The ID of the bookshelf to get")],
     db = Depends(get_db)
 ):
-    return db.execute(query='SELECT * FROM bookshelves WHERE id = ?', values=(bookshelf_id,)).fetchone()
+    with Session(db.get_engine()) as session:
+        bookshelf = session.get(Bookshelf, bookshelf_id)
+        if not bookshelf:
+            raise HTTPException(status_code=404, detail="Bookshelf not found")
+        return bookshelf
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+def create_bookshelf(
+    bookshelf_create: BookshelfCreate,
+    db = Depends(get_db)
+):
+    with Session(db.get_engine()) as session:
+        db_bookshelf = Bookshelf.model_validate(bookshelf_create)
+        session.add(db_bookshelf)
+        session.commit()
+
+    return None
 
 @router.patch("/{bookshelf_id}", status_code=status.HTTP_204_NO_CONTENT)
 def update_bookshelf(
@@ -33,18 +45,15 @@ def update_bookshelf(
     bookshelf: BookshelfUpdate,
     db = Depends(get_db)
 ):
-    update_fields = []
-    parameters = []
-    
-    for attribute in BookshelfUpdate.__fields__.keys():
-        bookshelf_dict = bookshelf.__dict__
-        if bookshelf_dict[attribute] is not None:
-            update_fields.append(f"{attribute} = ?")
-            parameters.append(bookshelf_dict[attribute])
+    with Session(db.get_engine()) as session:
+        db_bookshelf = session.get(Bookshelf, bookshelf_id)
+        if not db_bookshelf:
+            raise HTTPException(status_code=404, detail="Bookshelf not found")
+        bookshelf_data = bookshelf.model_dump(exclude_unset=True)
+        db_bookshelf.sqlmodel_update(bookshelf_data)
+        session.add(db_bookshelf)
+        session.commit()
 
-    query = f"UPDATE bookshelves SET {', '.join(update_fields)} WHERE id = ?"
-    parameters.append(bookshelf_id)
-    db.execute(query=query, values=parameters)
     return None
 
 @router.delete("/{bookshelf_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -52,22 +61,35 @@ def delete_bookshelf(
     bookshelf_id: Annotated[int, Path(title="The ID of the bookshelf to delete")],
     db = Depends(get_db)
 ):
-    db.execute(query='DELETE FROM bookshelves WHERE id = ?', values=(bookshelf_id,))
-    return None
+    with Session(db.get_engine()) as session:
+        bookshelf = session.get(Bookshelf, bookshelf_id)
+        if not bookshelf:
+            raise HTTPException(status_code=404, detail="Bookshelf not found")
+        session.delete(bookshelf)
+        session.commit()
 
-@router.get("/{bookshelf_id}/books", status_code=status.HTTP_200_OK)
-def get_bookshelf_books(
-    bookshelf_id: Annotated[int, Path(title="The ID of the bookshelf whose books we want to see")],
-    db = Depends(get_db)
-):
-    return db.execute(query='SELECT books.* FROM books JOIN bookshelves_books ON books.id = bookshelves_books.book_id WHERE bookshelves_books.bookshelf_id = ?', values=(bookshelf_id,)).fetchall()
+    return None
 
 @router.get("/{bookshelf_id}/books/exclude", status_code=status.HTTP_200_OK)
 def get_bookshelf_books(
     bookshelf_id: Annotated[int, Path(title="The ID of the bookshelf for which we want to see books NOT on the shelf")],
     db = Depends(get_db)
 ):
-    return db.execute(query='SELECT books.* FROM books WHERE books.id NOT IN (SELECT books.id FROM books JOIN bookshelves_books ON books.id = bookshelves_books.book_id WHERE bookshelves_books.bookshelf_id = ?)', values=(bookshelf_id,)).fetchall()
+    with Session(db.get_engine()) as session:
+        # Create a subquery to select book IDs that are in the bookshelf
+        subquery = select(BookBookshelfLink.book_id).where(BookBookshelfLink.bookshelf_id == bookshelf_id).distinct()
+
+        # Main query to select books not in the subquery results
+        query = (
+            select(Book)
+            .where(Book.id.not_in(subquery))
+        )
+        
+        # Execute the query and fetch all results
+        result = session.exec(query)
+        books = result.fetchall()
+
+    return books
 
 @router.post("/{bookshelf_id}/books", status_code=status.HTTP_201_CREATED)
 def add_book_to_bookshelf(
@@ -75,16 +97,27 @@ def add_book_to_bookshelf(
     book_ids: BookIds,
     db = Depends(get_db)
 ):
-    # TODO should be able to roll this back on partial success
-    try:
+    with Session(db.get_engine()) as session:
+        # Fetch the bookshelf
+        bookshelf = session.get(Bookshelf, bookshelf_id)
+        if not bookshelf:
+            raise HTTPException(status_code=404, detail="Bookshelf not found")
+        
+        # Fetch all the books
+        books_to_add = []
         for book_id in book_ids.book_ids:
-            db.execute(
-                query='INSERT INTO bookshelves_books (bookshelf_id, book_id) VALUES (?, ?)',
-                values=(bookshelf_id, book_id,)
-            )
-    except Exception as e:
-        print(e)
-        raise HTTPException(status_code=500, detail="Error adding books to bookshelf")
+            book = session.get(Book, book_id)
+            if not book:
+                raise HTTPException(status_code=404, detail=f"Book with ID {book_id} not found")
+            
+            books_to_add.append(book)
+        
+        # Add all the books to the bookshelf's books list
+        bookshelf.books.extend(books_to_add)
+        
+        # Commit the changes
+        session.commit()
+
     return None
 
 @router.delete("/{bookshelf_id}/books/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -93,5 +126,20 @@ def delete_book_from_bookshelf(
     book_id: Annotated[int, Path(title="The ID of the book to delete")],
     db = Depends(get_db)
 ):
-    db.execute(query='DELETE FROM bookshelves_books WHERE bookshelf_id = ? AND book_id = ?', values=(bookshelf_id,book_id,))
+    with Session(db.get_engine()) as session:
+        # Retrieve the Bookshelf instance
+        bookshelf = session.get(Bookshelf, bookshelf_id)
+        if not bookshelf:
+            raise HTTPException(status_code=404, detail="Bookshelf not found")
+
+        # Retrieve the Book instance to remove
+        book_to_remove = session.get(Book, book_id)
+        if not book_to_remove:
+            raise HTTPException(status_code=404, detail="Book not found")
+
+        # Remove the book from the bookshelf
+        if book_to_remove in bookshelf.books:
+            bookshelf.books.remove(book_to_remove)
+            session.commit()
+
     return None

--- a/backend/app/routers/bookshelves.py
+++ b/backend/app/routers/bookshelves.py
@@ -70,7 +70,7 @@ def delete_bookshelf(
 
     return None
 
-@router.get("/{bookshelf_id}/books/exclude", status_code=status.HTTP_200_OK)
+@router.get("/{bookshelf_id}/books/exclude/", status_code=status.HTTP_200_OK)
 def get_bookshelf_books(
     bookshelf_id: Annotated[int, Path(title="The ID of the bookshelf for which we want to see books NOT on the shelf")],
     db = Depends(get_db)
@@ -91,7 +91,7 @@ def get_bookshelf_books(
 
     return books
 
-@router.post("/{bookshelf_id}/books", status_code=status.HTTP_201_CREATED)
+@router.post("/{bookshelf_id}/books/", status_code=status.HTTP_201_CREATED)
 def add_book_to_bookshelf(
     bookshelf_id: Annotated[int, Path(title="The ID of the bookshelf to add a book to.")],
     book_ids: BookIds,

--- a/frontend/src/components/Bookshelves/Bookshelf.js
+++ b/frontend/src/components/Bookshelves/Bookshelf.js
@@ -179,15 +179,14 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
             <Row>
               {booksThatCanBeAdded.map((book) => (
                 <Col 
-                  className='m-3'
+                  className='m-3 border border-2 border-light'
                   onClick={(event) => toggleBookSelection(event, book.id)}
-                  style={{'height': '175px', 'min-height': '175px', 'min-width': '100px', 'padding': '2px'}}
+                  style={{'height': '175px', 'min-width': '100px', 'padding': '2px', 'boxSizing': 'border-box'}}
                 >
                   <LazyImage 
                     src={book.cover_uri} 
                     alt="Book Cover" 
-                    class="border border-2 border-light" 
-                    style={{'boxSizing': 'border-box', 'height': '175px', 'min-height': '175px', 'min-width': '100px', 'padding': '2px'}}
+                    style={{'max-width': '100%', 'max-height': '100%'}}
                     rootElement={document.querySelector('.modal-content')}
                   ></LazyImage>
                 </Col>

--- a/frontend/src/components/Bookshelves/Bookshelf.js
+++ b/frontend/src/components/Bookshelves/Bookshelf.js
@@ -5,7 +5,7 @@ import Container from 'react-bootstrap/Container';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import { NavLink, useParams, useNavigate } from 'react-router-dom';
-import { GetBookshelfBooks, GetBookshelf, DeleteBookshelf, GetBooksNotOnBookshelf, AddBooksToBookshelf, DeleteBookFromBookshelf } from '../../services/bookshelves'
+import { GetBookshelf, DeleteBookshelf, GetBooksNotOnBookshelf, AddBooksToBookshelf, DeleteBookFromBookshelf } from '../../services/bookshelves'
 import {confirm} from 'react-bootstrap-confirmation';
 import LazyImage from '../common/LazyLoadImage';
 
@@ -33,21 +33,8 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
     }
   }, [id]);
 
-  const fetchBooks = useCallback(async () => {
-    try {
-      // TODO Limit books we fetch depending on preview or not
-      const data = await GetBookshelfBooks(id);
-      setBooks(data);
-    } catch (error) {
-      console.error('Error fetching bookshelf books:', error);
-    } finally {
-      setLoading(false);
-    }
-  }, [id]);
-
   useEffect(() => {
     fetchData();
-    fetchBooks();
   }, [id, fetchData, fetchBooks]);
 
   useEffect(() => {

--- a/frontend/src/components/Bookshelves/Bookshelf.js
+++ b/frontend/src/components/Bookshelves/Bookshelf.js
@@ -15,7 +15,6 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
   const id = bookshelfId || useParamsId.id;
 
   const [data, setData] = useState([]);
-  const [books, setBooks] = useState([]);
   const [booksToAdd, setBooksToAdd] = useState([]);
   const [booksThatCanBeAdded, setBooksThatCanBeAdded] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -152,7 +151,7 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
             <button type="button" className="btn btn-outline-primary" style={{ 'width': '90px', 'height': '150px' }} onClick={handleShowModal}>+</button>
           </Col>
         )}
-        {books.map((book) => (
+        {data.books.map((book) => (
           <Col md="auto" className="mt-3" style={{ 'min-height': '150px', 'min-width': '80px' }}>
             <div class="bookshelf-book-image-wrapper" style={{ 'min-height': '150px', 'min-width': '80px' }}>
               <img 

--- a/frontend/src/components/Bookshelves/Bookshelf.js
+++ b/frontend/src/components/Bookshelves/Bookshelf.js
@@ -71,7 +71,7 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
       await AddBooksToBookshelf(id, booksToAdd);
     }
     setShowModal(false);
-    fetchBooks();
+    fetchData();
   };
 
   const handleDeleteBookFromBookshelf = async (e, bookToDelete) => {
@@ -79,7 +79,7 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
     const result = await confirm('Are you sure you want to remove this book from this bookshelf?');
     if (result) {
       await DeleteBookFromBookshelf(id, bookToDelete);
-      fetchBooks();
+      fetchData();
     }
   };
 

--- a/frontend/src/components/Bookshelves/Bookshelf.js
+++ b/frontend/src/components/Bookshelves/Bookshelf.js
@@ -35,7 +35,7 @@ function Bookshelf({ bookshelfId = null, preview = false }) {
 
   useEffect(() => {
     fetchData();
-  }, [id, fetchData, fetchBooks]);
+  }, [id, fetchData]);
 
   useEffect(() => {
     console.log('Updated booksToAdd:', booksToAdd);

--- a/frontend/src/components/books/Book.js
+++ b/frontend/src/components/books/Book.js
@@ -186,7 +186,7 @@ function Book({ bookId = null, preview = false }) {
             <img src={coverUri} className="img-fluid" alt="Book Cover" loading="lazy" />
           </NavLink>
         </Col>
-        <Col className='text-truncate' xs={ olids && olids.length > 0 ? 5 : 9}>
+        <Col xs={ olids && olids.length > 0 ? 5 : 9}>
           { preview && (
             <NavLink 
               className="nav-link" 

--- a/frontend/src/components/books/CreateBook.js
+++ b/frontend/src/components/books/CreateBook.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom'
-import { CreateBook as CreateBookService, GetBookCategories, SearchBookByTitle } from '../../services/books';
+import { CreateBook as CreateBookService, SearchBookByTitle } from '../../services/books';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Container from 'react-bootstrap/Container';
@@ -11,7 +11,6 @@ function CreateBook() {
   const [author, setAuthor] = useState('');
   const [year, setYear] = useState('');
   const [olid, setOlid] = useState('');
-  const [availableCategories, setAvailableCategories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searching, setSearching] = useState(false);
   const [searchResults, setSearchResults] = useState(false);
@@ -83,21 +82,6 @@ function CreateBook() {
       });
     }
   };
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const data = await GetBookCategories();
-        setAvailableCategories(data);
-      } catch (error) {
-        console.error('Error fetching book categories:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, []);
 
   useEffect(() => {
     if (olids.length === 0) {

--- a/frontend/src/components/books/CreateBook.js
+++ b/frontend/src/components/books/CreateBook.js
@@ -11,7 +11,6 @@ function CreateBook() {
   const [author, setAuthor] = useState('');
   const [year, setYear] = useState('');
   const [olid, setOlid] = useState('');
-  const [loading, setLoading] = useState(true);
   const [searching, setSearching] = useState(false);
   const [searchResults, setSearchResults] = useState(false);
   const [noResults, setNoResults] = useState(false);
@@ -99,10 +98,6 @@ function CreateBook() {
       setCoverUrl('https://covers.openlibrary.org/b/olid/' + olidToToggle + '-L.jpg');
     }
   };
-
-  if (loading) {
-    return <div>Loading...</div>;
-  }
 
   return (
     <Container className="mt-4">

--- a/frontend/src/components/common/LazyLoadImage.js
+++ b/frontend/src/components/common/LazyLoadImage.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-const LazyImage = ({ src, alt, element_class, style, rootElement }) => {
+const LazyImage = ({ src, alt, elementClass, style, rootElement }) => {
   const imgRef = useRef();
 
   console.log('root element', rootElement);
@@ -33,7 +33,7 @@ const LazyImage = ({ src, alt, element_class, style, rootElement }) => {
     
   }, [src, rootElement]);
 
-  return <img ref={imgRef} data-src={src} alt={alt} loading="lazy" class={element_class} style={style}/>;
+  return <img ref={imgRef} data-src={src} alt={alt} loading="lazy" className={elementClass} style={style}/>;
 };
 
 export default LazyImage;

--- a/frontend/src/services/books.js
+++ b/frontend/src/services/books.js
@@ -22,7 +22,7 @@ export const GetBook = async (id) => {
 };
 
 export const UpdateBook = async (id, data) => {
-    return await fetch(`${API_BASE_URL}/books/${id}/`, {
+    return await fetch(`${API_BASE_URL}/books/${id}`, {
         method: 'PATCH',
         headers: {
             'Content-Type': 'application/json',
@@ -32,15 +32,10 @@ export const UpdateBook = async (id, data) => {
 }
 
 export const DeleteBook = async (id) => {
-    await fetch(`${API_BASE_URL}/books/${id}/`, {
+    await fetch(`${API_BASE_URL}/books/${id}`, {
         method: 'DELETE',
     });
 }
-
-export const GetBookCategories = async () => {
-    const response = await fetch(`${API_BASE_URL}/books/categories/`);
-    return await response.json();
-};
 
 export const SearchBookByTitle = async (title) => {
     const response = await fetch(`${API_BASE_URL}/books/search/${title}`)

--- a/frontend/src/services/bookshelves.js
+++ b/frontend/src/services/bookshelves.js
@@ -31,18 +31,18 @@ export const UpdateBookshelf = async (id, data) => {
 }
 
 export const DeleteBookshelf = async (id) => {
-  return await fetch(`${API_BASE_URL}/bookshelves/${id}/`, {
+  return await fetch(`${API_BASE_URL}/bookshelves/${id}`, {
     method: 'DELETE',
   });
 }
 
 export const GetBooksNotOnBookshelf = async (id) => {
-  const response = await fetch(`${API_BASE_URL}/bookshelves/${id}/books/exclude`);
+  const response = await fetch(`${API_BASE_URL}/bookshelves/${id}/books/exclude/`);
   return await response.json();
 };
 
 export const AddBooksToBookshelf = async (bookshelfId, bookIds) => {
-  return await fetch(`${API_BASE_URL}/bookshelves/${bookshelfId}/books`, {
+  return await fetch(`${API_BASE_URL}/bookshelves/${bookshelfId}/books/`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/services/bookshelves.js
+++ b/frontend/src/services/bookshelves.js
@@ -36,11 +36,6 @@ export const DeleteBookshelf = async (id) => {
   });
 }
 
-export const GetBookshelfBooks = async (id) => {
-    const response = await fetch(`${API_BASE_URL}/bookshelves/${id}/books`);
-    return await response.json();
-  };
-
 export const GetBooksNotOnBookshelf = async (id) => {
   const response = await fetch(`${API_BASE_URL}/bookshelves/${id}/books/exclude`);
   return await response.json();


### PR DESCRIPTION
Here we are implementing an ORM instead of using raw SQL to speak to the database.

There a number of reasons for this:

1. We abstract the database to a degree that we can swap out our current SQLite with something like Posgres in the future if we want. The ORM knows how to speak to both
2. We get some SQL injection vulnerabilities handled for us
3. Cleaner code in general, dealing with classes and objects in Python

I ended up using [SQL Model](https://sqlmodel.tiangolo.com/) which I have found to be excellent thus far.

1. It is created by the same creator as FastAPI, so it plays very well 
2. It combines both Pydantic (for validation) and SQLAlchemy as an ORM, so we can write single classes that inherit from both and can be used for both validation and ORM. I was going to use SQLAlchemy when I stumbled upon this and so it seemed a no brainer to reduce code, boilerplate, repetition.
3. It seems very well documented and it was relatively easy to figure out how to do what I wanted to do

We also get better response formats, where previously we were just returning the DB results raw, now we at least package them via sql model as objects which feels cleaner, more organized.

At the same time, we did a bit of housekeeping, as certain routes were going away, like GETting a bookshelf's books, which are now returned with the bookshelf GET. Cleaning up front end to reflect changes. Also fixing issues of trailing slashes which resulted in redirects, and removing final remnants of categories.

Closes #11 
Closes #12 