### PR TITLE
Python Linter

### DIFF
--- a/backend/app/db/scripts/fetch_olids.py
+++ b/backend/app/db/scripts/fetch_olids.py
@@ -15,7 +15,6 @@ ol = OpenLibrary()
 
 
 async def fetch_titles_that_are_missing_olids():
-
     books_without_olids = []
 
     with Session(engine) as session:
@@ -43,6 +42,5 @@ titles = asyncio.run(fetch_titles_that_are_missing_olids())
 
 # Change this to run as many as needed, or loop through all
 for index in range(0, 1):
-
     olids = asyncio.run(get_olids_by_title(titles[index]))
     asyncio.run(update_book_by_title(titles[index], olids))

--- a/backend/app/db/scripts/fetch_olids.py
+++ b/backend/app/db/scripts/fetch_olids.py
@@ -19,7 +19,7 @@ async def fetch_titles_that_are_missing_olids():
     books_without_olids = []
 
     with Session(engine) as session:
-        books = session.exec(select(Book).where(Book.olids == None)).all()
+        books = session.exec(select(Book).where(Book.olids is None)).all()
         for book in books:
             books_without_olids.append(book.title)
 

--- a/backend/app/db/sqlite.py
+++ b/backend/app/db/sqlite.py
@@ -2,7 +2,6 @@ from sqlmodel import create_engine
 
 
 class DB:
-
     def __init__(self):
         self.sqlite_file_name = "bookshelf.db"
         self.sqlite_url = f"sqlite:///{self.sqlite_file_name}"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,9 +6,10 @@ from sqlmodel import SQLModel, text
 from app.db.sqlite import DB
 
 # These are only imported for the create_all call
-from app.models.book import Book
-from app.models.bookshelf import Bookshelf
-from app.models.book_bookshelf import BookBookshelfLink
+# `noqa: F401` is used to suppress linter errors
+from app.models.book import Book # noqa: F401
+from app.models.bookshelf import Bookshelf # noqa: F401
+from app.models.book_bookshelf import BookBookshelfLink # noqa: F401
 
 db = DB()
 engine = db.get_engine()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,9 +7,9 @@ from app.db.sqlite import DB
 
 # These are only imported for the create_all call
 # `noqa: F401` is used to suppress linter errors
-from app.models.book import Book # noqa: F401
-from app.models.bookshelf import Bookshelf # noqa: F401
-from app.models.book_bookshelf import BookBookshelfLink # noqa: F401
+from app.models.book import Book  # noqa: F401
+from app.models.bookshelf import Bookshelf  # noqa: F401
+from app.models.book_bookshelf import BookBookshelfLink  # noqa: F401
 
 db = DB()
 engine = db.get_engine()

--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -1,6 +1,6 @@
+from app.models.book_bookshelf import BookBookshelfLink
 from sqlmodel import SQLModel, Field, Relationship
 from typing import Optional, TYPE_CHECKING, List
-from app.models.book_bookshelf import BookBookshelfLink
 
 if TYPE_CHECKING:
     from app.models.bookshelf import Bookshelf  # Only imported when type checking
@@ -49,8 +49,9 @@ class BookUpdate(SQLModel):
 class BookPublicWithBookshelves(BookPublic):
     bookshelves: List["BookshelfPublic"] = []
 
-
-from app.models.bookshelf import BookshelfPublic
+# `noqa` is used to suppress linter errors
+# we needed the import here to avoid circular imports
+from app.models.bookshelf import BookshelfPublic # noqa
 
 BookPublicWithBookshelves.model_rebuild()
 

--- a/backend/app/models/book.py
+++ b/backend/app/models/book.py
@@ -49,9 +49,10 @@ class BookUpdate(SQLModel):
 class BookPublicWithBookshelves(BookPublic):
     bookshelves: List["BookshelfPublic"] = []
 
+
 # `noqa` is used to suppress linter errors
 # we needed the import here to avoid circular imports
-from app.models.bookshelf import BookshelfPublic # noqa
+from app.models.bookshelf import BookshelfPublic  # noqa
 
 BookPublicWithBookshelves.model_rebuild()
 

--- a/backend/app/models/bookshelf.py
+++ b/backend/app/models/bookshelf.py
@@ -36,8 +36,9 @@ class BookshelfUpdate(SQLModel):
 class BookshelfPublicWithBooks(BookshelfPublic):
     books: list["BookPublic"] = []
 
+
 # `noqa` is used to suppress linter errors
 # we needed the import here to avoid circular imports
-from app.models.book import BookPublic # noqa
+from app.models.book import BookPublic  # noqa
 
 BookshelfPublicWithBooks.model_rebuild()

--- a/backend/app/models/bookshelf.py
+++ b/backend/app/models/bookshelf.py
@@ -1,6 +1,6 @@
+from app.models.book_bookshelf import BookBookshelfLink
 from sqlmodel import SQLModel, Field, Relationship
 from typing import Optional, TYPE_CHECKING, List
-from app.models.book_bookshelf import BookBookshelfLink
 
 if TYPE_CHECKING:
     from app.models.book import Book, BookPublic  # Only imported when type checking
@@ -36,7 +36,8 @@ class BookshelfUpdate(SQLModel):
 class BookshelfPublicWithBooks(BookshelfPublic):
     books: list["BookPublic"] = []
 
-
-from app.models.book import BookPublic
+# `noqa` is used to suppress linter errors
+# we needed the import here to avoid circular imports
+from app.models.book import BookPublic # noqa
 
 BookshelfPublicWithBooks.model_rebuild()

--- a/backend/app/models/openlibrary.py
+++ b/backend/app/models/openlibrary.py
@@ -36,11 +36,9 @@ class Work(BaseModel):
 
 
 class Works(BaseModel):
-
     works: list[Work]
 
     def model_dump(self):
-
         dumped_works = [super_work.model_dump() for super_work in self.works]
 
         # Initialize an empty set to track seen authors

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -95,7 +95,7 @@ def delete_bookshelf(
 
 @router.get("/search/{title}", status_code=status.HTTP_200_OK)
 async def search_by_title(
-    title: Annotated[str, Path(title="The title we are searching for")]
+    title: Annotated[str, Path(title="The title we are searching for")],
 ):
     search_results: Works = await openlibrary.search_by_title(title=title)
 

--- a/backend/app/routers/bookshelves.py
+++ b/backend/app/routers/bookshelves.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, Path, status, HTTPException
-from typing import Annotated, List
+from typing import Annotated
 from app.models.bookshelf import (
     Bookshelf,
     BookshelfCreate,

--- a/backend/app/services/openlibrary.py
+++ b/backend/app/services/openlibrary.py
@@ -99,7 +99,7 @@ class OpenLibrary:
                 filename=olid
             )
 
-            if os.path.isfile(local_file_destination) == False:
+            if not os.path.isfile(local_file_destination):
                 # Download remote to local only if we don't already have the file
                 await self.image.download(
                     remote_url=open_library_url, local_filename=local_file_destination

--- a/backend/app/services/openlibrary.py
+++ b/backend/app/services/openlibrary.py
@@ -8,7 +8,6 @@ import urllib.parse
 
 
 class OpenLibrary:
-
     def __init__(self):
         self.search_title_url = "https://openlibrary.org/search.json?title={title}&"
 
@@ -27,7 +26,6 @@ class OpenLibrary:
         self.cover_uri = ""
 
     async def search_by_title(self, title: str) -> Dict[str, Any]:
-
         async with httpx.AsyncClient() as client:
             try:
                 url = self.build_search_url(title=title)
@@ -46,7 +44,6 @@ class OpenLibrary:
 
                 works = []
                 for doc in response_json["docs"]:
-
                     try:
                         Work.model_validate(doc)
                         works.append(Work(**doc))
@@ -60,7 +57,6 @@ class OpenLibrary:
                 return None
 
     def build_search_url(self, title) -> str:
-
         params = {
             self.search_fields_key: self.search_fields_separator.join(
                 self.search_fields_values
@@ -71,7 +67,6 @@ class OpenLibrary:
         )
 
     def find_olid(self, olid_response: Dict[str, Any]) -> str | None:
-
         olid = None
 
         if olid_response["numFound"] > 0:
@@ -84,11 +79,9 @@ class OpenLibrary:
         return olid
 
     def build_image_url_from_olid(self, olid: str) -> str:
-
         return self.cover_image_url.format(olid=olid, size=self.cover_image_size)
 
     async def fetch_image_from_olid(self, olid: str) -> str:
-
         if olid is None:
             self.cover_uri = self.image.default_cover_image
         else:
@@ -110,5 +103,4 @@ class OpenLibrary:
             self.cover_uri = self.image.get_cover_with_path_for_database(filename=olid)
 
     def get_cover_uri(self):
-
         return self.cover_uri

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -5,7 +5,6 @@ import sqlite3
 
 
 class DB:
-
     def __init__(self):
         self.connection = sqlite3.connect(":memory:", check_same_thread=False)
         self.connection.row_factory = sqlite3.Row
@@ -70,7 +69,6 @@ sys.modules["app.db.sqlite"] = module
 
 
 class OpenLibrary:
-
     def __init__(self):
         self.search_url = "https://openlibrary.org/search.json?title={title}"
 

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,3 +1,5 @@
+from app.models.book import Book
+from typing import Any, Dict
 import sys
 import sqlite3
 
@@ -65,10 +67,6 @@ def get_db():
 module = type(sys)("app.db.sqlite")
 module.get_db = get_db
 sys.modules["app.db.sqlite"] = module
-
-
-from app.models.book import Book
-from typing import Any, Dict
 
 
 class OpenLibrary:

--- a/backend/app/tests/integration/test_routes.py
+++ b/backend/app/tests/integration/test_routes.py
@@ -15,7 +15,7 @@ def test_create_bookshelf():
     body = {"title": "Bookshelf Title", "description": "Bookshelf Description"}
     response = client.post("/bookshelves", json=body)
     assert response.status_code == 201
-    assert response.json() == None
+    assert response.json() is None
 
 
 def test_get_bookshelves_after_create():
@@ -68,7 +68,7 @@ def test_create_book():
     body = {"title": "Book Title", "author": "Book Author", "year": 2000}
     response = client.post("/books", json=body)
     assert response.status_code == 201
-    assert response.json() == None
+    assert response.json() is None
 
 
 def test_get_books_after_create():
@@ -140,7 +140,7 @@ def test_add_book_to_bookshelf():
     body = {"book_id": book_id}
     response = client.post(f"/bookshelves/{bookshelf_id}/books", json=body)
     assert response.status_code == 201
-    assert response.json() == None
+    assert response.json() is None
 
 
 def test_get_bookshelf_books_after_add():

--- a/backend/app/utils/image.py
+++ b/backend/app/utils/image.py
@@ -3,9 +3,7 @@ import urllib
 
 
 class Image:
-
     def __init__(self):
-
         self.local_image_directory = "/assets/cover_images/"
         self.default_cover_image = "No_Image_Available.jpg"
         self.relative_path_to_file = (
@@ -14,7 +12,6 @@ class Image:
         self.image_file_extension = ".jpg"
 
     def sanitize_book_title_for_filename(self, book_title: str) -> str:
-
         return (
             "".join(c for c in book_title if c.isalpha() or c.isdigit() or c == " ")
             .replace(" ", "_")
@@ -22,7 +19,6 @@ class Image:
         )
 
     def determine_local_file_destination(self, filename: str) -> str:
-
         # Determine directory of our file
         current_directory = os.path.dirname(__file__)
 
@@ -35,17 +31,13 @@ class Image:
         )
 
     async def download(self, remote_url: str, local_filename: str) -> None:
-
         return urllib.request.urlretrieve(remote_url, local_filename)
 
     def get_local_image_directory(self) -> str:
-
         return self.local_image_directory
 
     def get_default_cover_with_path_for_database(self) -> str:
-
         return self.local_image_directory + self.default_cover_image
 
     def get_cover_with_path_for_database(self, filename: str) -> str:
-
         return self.local_image_directory + filename + self.image_file_extension


### PR DESCRIPTION
I installed [ruff](https://github.com/astral-sh/ruff), which I had heard about.

It seems people rave about its speed, so likely I could run it in a pre-commit hook.

Also, I didn't realize it includes formatting also, so it's possible this makes Black redundant? Or I could use Black for formatting and ruff for only linting?

TBD

This can be run with `ruff check --fix` and `ruff format` inside the backend directory