### PR TITLE
Search & Sort Books

### DIFF
--- a/frontend/src/components/books/Books.tsx
+++ b/frontend/src/components/books/Books.tsx
@@ -5,9 +5,13 @@ import Container from "react-bootstrap/Container";
 import Book from "./Book";
 import { GetBooks } from "../../services/books";
 import { BookInterface } from "../../interfaces/book_and_bookshelf";
+import styles from "./css/Books.module.css";
 
 function Books() {
   const [books, setBooks] = useState<BookInterface[]>([]);
+  const [search, setSearch] = useState<string | null>(null);
+  const [sort, setSort] = useState<string>("id");
+  const [sortDirection, setSortDirection] = useState<string>("ascending");
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -29,6 +33,20 @@ function Books() {
     void fetchData();
   }, []);
 
+  const handleSearch = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearch(event.currentTarget.value);
+  };
+
+  const handleSort = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSort(event.currentTarget.value);
+  };
+
+  const handleSortDirection = () => {
+    setSortDirection(
+      sortDirection === "ascending" ? "descending" : "ascending"
+    );
+  };
+
   if (loading) {
     return <div>Loading...</div>;
   }
@@ -36,17 +54,100 @@ function Books() {
   return (
     <Container>
       <Row>
-        {books.map((book: BookInterface) => (
-          <Col
-            xs={12}
-            md={6}
-            xl={4}
-            className="mt-3 mb-3"
-            key={`col-${book.id}`}
+        <Col xs={5} lg={3}>
+          <form className={`form-floating ${styles["custom-form-floating"]}`}>
+            <input
+              type="text"
+              placeholder="search..."
+              id="search"
+              name="search"
+              className="form-control form-control-sm"
+              onChange={handleSearch}
+            />
+            <label htmlFor="floatingInputValue">Search...</label>
+          </form>
+        </Col>
+        <Col xs={5} lg={3}>
+          <div className={`form-floating ${styles["custom-form-floating"]}`}>
+            <select
+              className="form-select"
+              id="floatingSelect"
+              aria-label="Floating label select example"
+              onChange={handleSort}
+            >
+              <option value="id" selected>
+                Date Added
+              </option>
+              <option value="title">Title</option>
+              <option value="author">Author</option>
+              <option value="year">Year</option>
+              <option value="rating">Rating</option>
+            </select>
+            <label htmlFor="floatingSelect">Sort by</label>
+          </div>
+        </Col>
+        <Col xs={2}>
+          <button
+            type="button"
+            className={`btn btn-outline-secondary ms-1 ${styles["custom-sort-button"]}`}
+            onClick={handleSortDirection}
           >
-            <Book bookId={book.id} preview={true} key={book.id} />
-          </Col>
-        ))}
+            {sortDirection === "ascending" && (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                fill="currentColor"
+                className="bi bi-sort-up"
+                viewBox="0 0 16 16"
+              >
+                <path d="M3.5 12.5a.5.5 0 0 1-1 0V3.707L1.354 4.854a.5.5 0 1 1-.708-.708l2-1.999.007-.007a.5.5 0 0 1 .7.006l2 2a.5.5 0 1 1-.707.708L3.5 3.707zm3.5-9a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5M7.5 6a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1zm0 3a.5.5 0 0 0 0 1h3a.5.5 0 0 0 0-1zm0 3a.5.5 0 0 0 0 1h1a.5.5 0 0 0 0-1z" />
+              </svg>
+            )}
+            {sortDirection === "descending" && (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                fill="currentColor"
+                className="bi bi-sort-down"
+                viewBox="0 0 16 16"
+              >
+                <path d="M3.5 2.5a.5.5 0 0 0-1 0v8.793l-1.146-1.147a.5.5 0 0 0-.708.708l2 1.999.007.007a.497.497 0 0 0 .7-.006l2-2a.5.5 0 0 0-.707-.708L3.5 11.293zm3.5 1a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5M7.5 6a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1zm0 3a.5.5 0 0 0 0 1h3a.5.5 0 0 0 0-1zm0 3a.5.5 0 0 0 0 1h1a.5.5 0 0 0 0-1z" />
+              </svg>
+            )}
+          </button>
+        </Col>
+      </Row>
+      <Row>
+        {books
+          .filter((book: BookInterface) => {
+            return search && search !== ""
+              ? book.title.toLowerCase().includes(search.toLowerCase())
+              : true;
+          })
+          .sort((bookA: BookInterface, bookB: BookInterface) => {
+            const sortKey = sort as keyof BookInterface;
+            const directionModifier = sortDirection === "ascending" ? 1 : -1;
+            if (bookA[sortKey] < bookB[sortKey]) {
+              return -1 * directionModifier;
+            } else if (bookA[sortKey] > bookB[sortKey]) {
+              return 1 * directionModifier;
+            }
+            // a must be equal to b
+            return 0;
+          })
+          .map((book: BookInterface) => (
+            <Col
+              xs={12}
+              md={6}
+              xl={4}
+              className="mt-3 mb-3"
+              key={`col-${book.id}`}
+            >
+              <Book bookId={book.id} preview={true} key={book.id} />
+            </Col>
+          ))}
       </Row>
     </Container>
   );

--- a/frontend/src/components/books/css/Books.module.css
+++ b/frontend/src/components/books/css/Books.module.css
@@ -1,0 +1,28 @@
+.custom-form-floating > :global(.form-control),
+.custom-form-floating > :global(.form-select) {
+  height: calc(2.5rem + calc(var(--bs-border-width) * 2)) !important;
+  min-height: calc(2.5rem + calc(var(--bs-border-width) * 2)) !important;
+}
+
+.custom-form-floating > :global(label) {
+  padding: 0.5rem 1rem !important;
+  height: 90% !important;
+}
+
+.custom-form-floating > :global(.form-control):focus ~ :global(label),
+.custom-form-floating
+  > :global(.form-control):not(:placeholder-shown)
+  ~ :global(label),
+.custom-form-floating > :global(.form-select) ~ :global(label) {
+  transform: scale(0.65) translateY(-0.5rem) translateX(0.15rem) !important;
+}
+
+.custom-form-floating > :global(.form-select) {
+  padding-top: 1rem !important;
+  padding-bottom: 0.5rem !important;
+  font-size: 0.75rem !important;
+}
+
+.custom-sort-button {
+  padding: 0.5rem 0.7rem !important;
+}


### PR DESCRIPTION
As our main 'books' view grows, it becomes challenging to find what you're looking for.

Adding search and sort features gives the user a quick way to drill down and find what they want, or order books by something semantically meaningful to them (as opposed to just the default of id).

It may become necessary to add search and sort to other views, but for now the books view seemed the only reasonable candidate.

Bookshelves don't/haven't grown as much, and I'd say are probably less likely to overall? But this could be added in the future. I wanted to avoid feature creep.

Closes #30 