### PR TITLE
Star Rating Removal

### DIFF
--- a/frontend/src/components/books/Book.tsx
+++ b/frontend/src/components/books/Book.tsx
@@ -28,7 +28,7 @@ function Book({ bookId, preview }: BookProps) {
   const [title, setTitle] = useState("");
   const [author, setAuthor] = useState("");
   const [year, setYear] = useState(0);
-  const [rating, setRating] = useState(0);
+  const [rating, setRating] = useState<number | null>(null);
   const [review, setReview] = useState("");
   const [savedReview, setSavedReview] = useState("");
   const [loading, setLoading] = useState(true);
@@ -161,10 +161,12 @@ function Book({ bookId, preview }: BookProps) {
   };
 
   const changeRating = async (newRating: number) => {
-    if (rating !== newRating) {
-      setRating(newRating);
-      await UpdateBook(_bookId, { rating: newRating });
+    let ratingToPropagate: number | null = newRating;
+    if (newRating === rating) {
+      ratingToPropagate = null;
     }
+    setRating(ratingToPropagate);
+    await UpdateBook(_bookId, { rating: ratingToPropagate });
   };
 
   const changeRatingClick = (event: React.MouseEvent<HTMLInputElement>) => {

--- a/frontend/src/interfaces/book_and_bookshelf.d.ts
+++ b/frontend/src/interfaces/book_and_bookshelf.d.ts
@@ -24,7 +24,7 @@ export interface CreateOrUpdateBookInterface {
   olid: string;
   cover_uri: string;
   olids: string;
-  rating: number;
+  rating: number | null;
   review: string;
   read_status: string;
   read_start_date: string | null;


### PR DESCRIPTION
A user may want to remove a star rating they gave, either on purpose or in error.

Now we allow a click on an already-selected star rating to perform this action of nullifying the rating altogether.

Closes #37