### PR TITLE
Delete Confirmation

### DIFF
--- a/frontend/src/components/books/Book.tsx
+++ b/frontend/src/components/books/Book.tsx
@@ -3,6 +3,8 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import { useParams, useNavigate, NavLink } from "react-router-dom";
 import { GetBook, DeleteBook, UpdateBook } from "../../services/books";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
 import Container from "react-bootstrap/esm/Container";
 import styles from "./css/Book.module.scss";
 import { BookWithBookshelvesInterface } from "../../interfaces/book_and_bookshelf";
@@ -40,6 +42,7 @@ function Book({ bookId, preview }: BookProps) {
   const [readStartDate, setReadStartDate] = useState<Date | null>(null);
   const [readEndDate, setReadEndDate] = useState<Date | null>(null);
   const [addingReview, setAddingReview] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const reviewPlaceholder = "Share your thoughts on this book ...";
   const navigate = useNavigate();
 
@@ -109,22 +112,18 @@ function Book({ bookId, preview }: BookProps) {
   };
 
   const handleDelete = async () => {
-    // const result = await confirm("Are you sure you want to delete this book?");
-    const result = true;
-    if (result) {
-      const response: boolean = await DeleteBook(_bookId);
-      if (!response) {
-        // A message to the user may be warranted here
-        // Especially if we are going to prevent navigation
-        return false;
-      }
-      navigate(`/books/`);
+    const response: boolean = await DeleteBook(_bookId);
+    if (!response) {
+      // A message to the user may be warranted here
+      // Especially if we are going to prevent navigation
+      return false;
     }
+    navigate(`/books/`);
   };
 
   const handleDeleteClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
-    void handleDelete(); // Call the async function but don't return its Promise
+    setShowDeleteModal(true);
   };
 
   const imageOnload = (
@@ -392,6 +391,10 @@ function Book({ bookId, preview }: BookProps) {
       start ? start.toISOString() : null,
       end ? end.toISOString() : null
     );
+  };
+
+  const handleCloseDeleteModal = () => {
+    setShowDeleteModal(false);
   };
 
   useEffect(() => {
@@ -742,6 +745,20 @@ function Book({ bookId, preview }: BookProps) {
           </>
         )}
       </Row>
+      <Modal show={showDeleteModal} onHide={handleCloseDeleteModal} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Warning</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>Are you sure you want to delete this book?</Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleCloseDeleteModal}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleDelete}>
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal>
     </Container>
   );
 }

--- a/frontend/src/components/bookshelves/Bookshelf.tsx
+++ b/frontend/src/components/bookshelves/Bookshelf.tsx
@@ -44,6 +44,7 @@ function Bookshelf({ bookshelfId, preview }: BookshelfProps) {
   const [showModal, setShowModal] = useState(false);
   const [sortKey, setSortKey] = useState("");
   const [sortDirection, setSortDirection] = useState("");
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const navigate = useNavigate();
 
   const fetchBookshelf = useCallback(async () => {
@@ -85,24 +86,18 @@ function Bookshelf({ bookshelfId, preview }: BookshelfProps) {
   };
 
   const handleDelete = async () => {
-    // const result = await confirm(
-    //   "Are you sure you want to delete this bookshelf?",
-    // );
-    const result = true;
-    if (result) {
-      const response: boolean = await DeleteBookshelf(_bookshelfId);
-      if (!response) {
-        // A message to the user may be warranted here
-        // Especially if we are going to prevent navigation
-        return false;
-      }
-      navigate(`/`);
+    const response: boolean = await DeleteBookshelf(_bookshelfId);
+    if (!response) {
+      // A message to the user may be warranted here
+      // Especially if we are going to prevent navigation
+      return false;
     }
+    navigate(`/`);
   };
 
   const handleDeleteClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
-    void handleDelete();
+    setShowDeleteModal(true);
   };
 
   const handleShowModal = () => {
@@ -224,6 +219,10 @@ function Bookshelf({ bookshelfId, preview }: BookshelfProps) {
       // A message to the user may be warranted here
       return false;
     }
+  };
+
+  const handleCloseDeleteModal = () => {
+    setShowDeleteModal(false);
   };
 
   if (!_bookshelfId || _bookshelfId === 0) {
@@ -449,6 +448,20 @@ function Bookshelf({ bookshelfId, preview }: BookshelfProps) {
           </Button>
           <Button variant="primary" onClick={handleSaveChangeClick}>
             Save Changes
+          </Button>
+        </Modal.Footer>
+      </Modal>
+      <Modal show={showDeleteModal} onHide={handleCloseDeleteModal} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Warning</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>Are you sure you want to delete this bookshelf?</Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleCloseDeleteModal}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleDelete}>
+            Delete
           </Button>
         </Modal.Footer>
       </Modal>


### PR DESCRIPTION
As stated in the single commit, we needed to add deletion confirmation for books and bookshelves, replacing an earlier package we had used that became impossible to use due to dependency conflicts.

Probably worked out for the best, as it is recreated very simple with a bootstrap modal.

Closes #46 