### PR TITLE
Handling Exceptions

### DIFF
--- a/backend/app/models/exception.py
+++ b/backend/app/models/exception.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from fastapi import status
+
+class ExceptionHandler(BaseModel):
+    status_code: int
+    message: str
+
+    def get_timeout_status_code():
+        return status.HTTP_504_GATEWAY_TIMEOUT
+    
+    def get_generic_status_code():
+        return status.HTTP_502_BAD_GATEWAY
+    
+    def get_no_results_status_code():
+        return status.HTTP_404_NOT_FOUND

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -8,6 +8,7 @@ from app.models.book import (
     BookPublicWithBookshelves,
 )
 from app.models.openlibrary import Works
+from app.models.exception import ExceptionHandler
 from app.services.openlibrary import OpenLibrary
 from app.db.sqlite import DB
 from app.utils.image import Image
@@ -97,9 +98,9 @@ def delete_bookshelf(
 async def search_by_title(
     title: Annotated[str, Path(title="The title we are searching for")],
 ):
-    search_results: Works = await openlibrary.search_by_title(title=title)
+    results: Works | ExceptionHandler = await openlibrary.search_by_title(title=title)
 
-    if not search_results:
-        return {}
+    if isinstance(results, ExceptionHandler):
+        raise HTTPException(status_code=results.status_code, detail=results.message)
 
-    return search_results.model_dump()
+    return results.model_dump()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.0",
         "react-scripts": "5.0.1",
+        "react-toastify": "^10.0.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -17301,6 +17302,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.5.tgz",
+      "integrity": "sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-transition-group": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.0",
     "react-scripts": "5.0.1",
+    "react-toastify": "^10.0.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import Books from "./components/books/Books";
 import Book from "./components/books/Book";
 import CreateBook from "./components/books/CreateBook";
 import Header from "./components/common/Header";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 function App() {
   return (
@@ -25,6 +27,7 @@ function App() {
           <Route path="/books/create" element={<CreateBook />} />
         </Routes>
       </Container>
+      <ToastContainer />
     </Router>
   );
 }


### PR DESCRIPTION
When we experienced Open Library's API timing out, there was no useful explanation for the user.

Now we catch various errors that happen on the backend, including via OL, and surface those to the client.

Then on the client side, we use a notification package to cleanly and uniformly notify the user of an error.

The two most common issues we are likely to see are:

1. An Open Library timeout, which is communicated as such. In my experience, this can be arbitrary, depending on the state of their service.
2. Open Library finding no results based on our search, which will also be communicated as such. A user will then at least know that their search does not produce anything and they can amend it accordingly.


Closes #49 