### PR TITLE
Reducing API Calls

### DIFF
--- a/frontend/src/components/bookshelves/Bookshelf.tsx
+++ b/frontend/src/components/bookshelves/Bookshelf.tsx
@@ -130,6 +130,7 @@ function Bookshelf({ bookshelfId, preview }: BookshelfProps) {
   };
 
   const handleDeleteBookFromBookshelf = async (bookToDelete: number) => {
+    // TODO this needs to be replaced with our delete confirmation modal
     // const result = await confirm(
     //   "Are you sure you want to remove this book from this bookshelf?",
     // );
@@ -351,9 +352,21 @@ function Bookshelf({ bookshelfId, preview }: BookshelfProps) {
             .sort((bookA: BookInterface, bookB: BookInterface) => {
               const localSortKey = sortKey as keyof BookInterface;
               const directionModifier = sortDirection === "ascending" ? 1 : -1;
-              if (bookA[localSortKey] < bookB[localSortKey]) {
+              let nullPosition = Infinity;
+              if (directionModifier === -1) {
+                nullPosition = 0;
+              }
+              const bookAComparison =
+                bookA[localSortKey] !== null
+                  ? bookA[localSortKey]
+                  : nullPosition;
+              const bookBComparison =
+                bookB[localSortKey] !== null
+                  ? bookB[localSortKey]
+                  : nullPosition;
+              if (bookAComparison < bookBComparison) {
                 return -1 * directionModifier;
-              } else if (bookA[localSortKey] > bookB[localSortKey]) {
+              } else if (bookAComparison > bookBComparison) {
                 return 1 * directionModifier;
               }
               // a must be equal to b

--- a/frontend/src/interfaces/book_and_bookshelf.d.ts
+++ b/frontend/src/interfaces/book_and_bookshelf.d.ts
@@ -6,7 +6,7 @@ export interface BookInterface {
   olid: string;
   cover_uri: string;
   olids: string;
-  rating: number;
+  rating: number | null;
   review: string;
   read_status: string;
   read_start_date: string;
@@ -14,7 +14,7 @@ export interface BookInterface {
 }
 
 export interface BookWithBookshelvesInterface extends BookInterface {
-  bookshelves: BookshelfInterface[];
+  bookshelves?: BookshelfInterface[];
 }
 
 export interface CreateOrUpdateBookInterface {

--- a/frontend/src/services/books.ts
+++ b/frontend/src/services/books.ts
@@ -1,13 +1,14 @@
 import { Base } from "./base";
 import {
-  BookInterface,
   BookWithBookshelvesInterface,
   CreateOrUpdateBookInterface,
 } from "../interfaces/book_and_bookshelf";
 import { WorkInterface } from "../interfaces/work";
 const API_BASE_URL = "http://127.0.0.1:8000";
 
-export const GetBooks = async (): Promise<BookInterface[] | boolean> => {
+export const GetBooks = async (): Promise<
+  BookWithBookshelvesInterface[] | boolean
+> => {
   return await Base(`${API_BASE_URL}/books/`);
 };
 


### PR DESCRIPTION
When we loaded our Books component previously, it loaded individual Book components to load the book previews.

The issue was, when we loaded our Books component, we fetched all books, and then each Book component fetched itself, using the ID only.

This was redundant and lead to as many API calls as there are books on the Books component.

We now we pass the entire book object into the Book component so it doesn't need to fetch itself.

It still fetches itself if we navigate directly to it, because we are not being passed the full book object.

This shows a marked improvement in the loading time for the Books component, and user experience.

Closes #55 